### PR TITLE
Update influxdb-line-protocol.js

### DIFF
--- a/influxdb-line-protocol.js
+++ b/influxdb-line-protocol.js
@@ -42,7 +42,8 @@ function parseValue(value) {
   if (value == null) {
     return undefined
   } else if (INT_REGEX.test(value)) {
-    return parseInt(value.slice(0, -1))
+    return value
+    /*return parseInt(value.slice(0, -1))*/
   } else if (TRUE_REGEX.test(value)) {
     return true
   } else if (FALSE_REGEX.test(value)) {


### PR DESCRIPTION
conversion from lineprotocol to json: for integer values, keep format as is (string and with "i" as suffix), otherwise value is automatically converted to float and information about int type is lost.  conversion to float can be done outside this node (or as a checkbox option inside the node?  LPtoJSON -> convert int to number)